### PR TITLE
Suggested changes

### DIFF
--- a/style.css
+++ b/style.css
@@ -231,6 +231,8 @@ padding-bottom:8em;
 }
 .drinkMenu {
 padding-left: 5em;
+display: grid;
+grid-template-columns: auto auto auto;
 }
 .drinks {
   -webkit-box-shadow: 0px 3px 25px 0px rgba(0,0,0,0.75);

--- a/style.css
+++ b/style.css
@@ -228,18 +228,14 @@ padding-top: 3em;
 width: 100%;
 padding-top:8em;
 padding-bottom:8em;
-height: 100vh;
-
 }
 .drinkMenu {
-position: absolute;
 padding-left: 5em;
 }
 .drinks {
   -webkit-box-shadow: 0px 3px 25px 0px rgba(0,0,0,0.75);
 margin:10px;
 border: 1px solid black;
-float: left;
 width:380px;
 }
 


### PR DESCRIPTION
Here are a couple changes to get the footer to not overlap while allowing the menu grid work.

See the comments in these two commits for more details.

Should result in this: 

<img width="1552" alt="Screen Shot 2019-04-07 at 10 58 39 PM" src="https://user-images.githubusercontent.com/44956/55695934-ce1de200-5988-11e9-804d-dbe8bad43554.png">
